### PR TITLE
add cancel_pending tcl command in pl/tcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 This repository is meant to facilitate development and potential release of pl/tcl
 features outside of the normal Postgres release process.
 
+# Requirements
+
+* PostgreSQL source tree
+* Tcl 8.6 or later
+
 # Building
 In order to build from this repository, you must have a checkout of the full Postgres
 source code. In that checkout, make certain that you can build and run pl/tcl. IE:

--- a/pltcl.c
+++ b/pltcl.c
@@ -45,10 +45,12 @@ PG_MODULE_MAGIC;
 	((TCL_MAJOR_VERSION > maj) || \
 	 (TCL_MAJOR_VERSION == maj && TCL_MINOR_VERSION >= min))
 
-/* Insist on Tcl >= 8.5 */
-#if !HAVE_TCL_VERSION(8,5)
-/* This extension uses Tcl_SetNotifier which requires Tcl 8.5 or later. */
-#error The PostgreSQL Tcl extension only supports Tcl 8.5 or later.
+/* Insist on Tcl >= 8.6 */
+#if !HAVE_TCL_VERSION(8,6)
+/* This extension uses Tcl_SetNotifier which requires Tcl 8.5 or later,
+ * and Tcl8.5 does not take consts in callback types such as (Tcl_SetTimerProc).
+ */
+#error The PostgreSQL pltcl extension only supports Tcl 8.6 or later.
 #endif
 
 /* define our text domain for translations */

--- a/pltcl.c
+++ b/pltcl.c
@@ -45,9 +45,10 @@ PG_MODULE_MAGIC;
 	((TCL_MAJOR_VERSION > maj) || \
 	 (TCL_MAJOR_VERSION == maj && TCL_MINOR_VERSION >= min))
 
-/* Insist on Tcl >= 8.4 */
-#if !HAVE_TCL_VERSION(8,4)
-#error PostgreSQL only supports Tcl 8.4 or later.
+/* Insist on Tcl >= 8.5 */
+#if !HAVE_TCL_VERSION(8,5)
+/* This extension uses Tcl_SetNotifier which requires Tcl 8.5 or later. */
+#error The PostgreSQL Tcl extension only supports Tcl 8.5 or later.
 #endif
 
 /* define our text domain for translations */

--- a/pltcl.c
+++ b/pltcl.c
@@ -50,11 +50,6 @@ PG_MODULE_MAGIC;
 #error PostgreSQL only supports Tcl 8.4 or later.
 #endif
 
-/* Hack to deal with Tcl 8.6 const-ification without losing compatibility */
-#ifndef CONST86
-#define CONST86
-#endif
-
 /* define our text domain for translations */
 #undef TEXTDOMAIN
 #define TEXTDOMAIN PG_TEXTDOMAIN("pltcl")
@@ -353,7 +348,7 @@ pltcl_FinalizeNotifier(ClientData clientData)
 }
 
 static void
-pltcl_SetTimer(CONST86 Tcl_Time *timePtr)
+pltcl_SetTimer(const Tcl_Time *timePtr)
 {
 }
 
@@ -379,7 +374,7 @@ pltcl_ServiceModeHook(int mode)
 }
 
 static int
-pltcl_WaitForEvent(CONST86 Tcl_Time *timePtr)
+pltcl_WaitForEvent(const Tcl_Time *timePtr)
 {
 	return 0;
 }

--- a/pltcl.c
+++ b/pltcl.c
@@ -286,6 +286,8 @@ static void pltcl_construct_errorCode(Tcl_Interp *interp, ErrorData *edata);
 static const char *pltcl_get_condition_name(int sqlstate);
 static int pltcl_quote(ClientData cdata, Tcl_Interp *interp,
 			int objc, Tcl_Obj *const objv[]);
+static int pltcl_cancel_pending(ClientData cdata, Tcl_Interp *interp,
+			int objc, Tcl_Obj *const objv[]);
 static int pltcl_argisnull(ClientData cdata, Tcl_Interp *interp,
 				int objc, Tcl_Obj *const objv[]);
 static int pltcl_returnnull(ClientData cdata, Tcl_Interp *interp,
@@ -504,6 +506,8 @@ pltcl_init_interp(pltcl_interp_desc *interp_desc, Oid prolang, bool pltrusted)
 						 pltcl_elog, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "quote",
 						 pltcl_quote, NULL, NULL);
+	Tcl_CreateObjCommand(interp, "cancel_pending",
+						 pltcl_cancel_pending, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "argisnull",
 						 pltcl_argisnull, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "return_null",
@@ -1957,6 +1961,16 @@ pltcl_get_condition_name(int sqlstate)
 	return "unrecognized_sqlstate";
 }
 
+/**********************************************************************
+ * pltcl_cancel_pending()	- return state of the global
+ *                                QueryCancelPending
+ **********************************************************************/
+static int
+pltcl_cancel_pending(ClientData cdata, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
+{
+	Tcl_SetObjResult(interp, Tcl_NewIntObj(QueryCancelPending));
+	return TCL_OK;
+}
 
 /**********************************************************************
  * pltcl_quote()	- quote literal strings that are to

--- a/stand-alone.mk
+++ b/stand-alone.mk
@@ -28,9 +28,3 @@ check-fail:
 	@echo '"$(MAKE) check" is not supported.'
 	@echo 'Do "$(MAKE) install", then "$(MAKE) installcheck" instead.'
 	@exit 1
-#
-# By default, postgres doesn't consider install to be a dependency of
-# installcheck. I've never understood why, but it's annoying. While were
-# mucking around, fix that.
-
-installcheck: install


### PR DESCRIPTION
This adds a command [cancel_pending] that can be used in long running scripts to abort if the query that triggered them has been cancelled.
